### PR TITLE
Add options to invert and swap axes plus add typing

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -6,3 +6,12 @@ Ensure your device works with this simple test.
 .. literalinclude:: ../examples/tsc2007_simpletest.py
     :caption: examples/tsc2007_simpletest.py
     :linenos:
+
+Display Specific test
+----------------------
+
+Initialize a display and set options so that axes are correct to rotation.
+
+.. literalinclude:: ../examples/tsc2007_3.5_feather_v2.py
+    :caption: examples/tsc2007_3.5_feather_v2.py
+    :linenos:

--- a/examples/tsc2007_3.5_feather_v2.py
+++ b/examples/tsc2007_3.5_feather_v2.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: Unlicense
+
+
+import board
+import displayio
+from adafruit_hx8357 import HX8357
+import adafruit_tsc2007
+
+# Initialize the Display
+displayio.release_displays()
+
+spi = board.SPI()
+tft_cs = board.D9
+tft_dc = board.D10
+
+display_bus = displayio.FourWire(spi, command=tft_dc, chip_select=tft_cs)
+display = HX8357(display_bus, width=480, height=320)
+
+# Use for I2C
+i2c = board.I2C()  # uses board.SCL and board.SDA
+# i2c = board.STEMMA_I2C()  # For using the built-in STEMMA QT connector on a microcontroller
+
+tsc = adafruit_tsc2007.TSC2007(i2c, invert_x=True, swap_xy=True)
+
+while True:
+    if tsc.touched:
+        point = tsc.touch
+        if point["pressure"] < 100:  # ignore touches with no 'pressure' as false
+            continue
+        print("Touchpoint: (%d, %d, %d)" % (point["x"], point["y"], point["pressure"]))


### PR DESCRIPTION
Fixes #5. I decided to go with the solution that the raspberry pi uses and add some invert and swap options. By default, the driver will behave as it does now. I also added typing to the library.